### PR TITLE
Added like button for posts

### DIFF
--- a/security-rules.json
+++ b/security-rules.json
@@ -38,6 +38,11 @@
         "replyTo": {
           ".validate": "!newData.exists() || newData.isString()"
         },
+        "likes": {
+          "$uid" : {
+          	".write": "auth !== null && (auth.uid === $uid)"
+          }
+        },
         "user": {
           "displayName": {
             ".validate": "newData.isString()"
@@ -127,7 +132,12 @@
           "$threadId": {
             ".validate": "newData.isBoolean()"
           }
-        }
+        },
+        "likes": {
+          "$postId" : {
+          	".write": "auth !== null && (auth.uid === $uid)"
+          }
+        },
       }
     },
     "settings": {

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -22,6 +22,7 @@ class App extends Component {
 
   render() {
     const {
+      siteName,
       children,
       loading,
       user,
@@ -49,6 +50,7 @@ class App extends Component {
         />
         <div>
           <TopBar
+            siteName = {siteName || "refire"}
             authenticatedUser={authenticatedUser}
             user={user}
             board={board}

--- a/src/App/Index.js
+++ b/src/App/Index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { bindings } from 'refire-app'
 import themes from '../themes'
+import { siteName } from '../config'
 
 import App from './App'
 
@@ -45,6 +46,7 @@ class Index extends Component {
 
     return (
       <App
+        siteName={siteName}
         loading={loading}
         user={user}
         board={board}

--- a/src/App/TopBar.js
+++ b/src/App/TopBar.js
@@ -5,6 +5,7 @@ import BoardLink from './BoardLink'
 import SettingsButton from './SettingsButton'
 
 const TopBar = ({
+  siteName,
   authenticatedUser,
   board,
   boardKey,
@@ -19,7 +20,7 @@ const TopBar = ({
       <div className={styles.topbar}>
         <h1 className={styles.header}>
           <Link to="/" className={styles.link}>
-            refire
+            { siteName }
           </Link>
           <BoardLink
             board={board}

--- a/src/Thread/Index.js
+++ b/src/Thread/Index.js
@@ -6,7 +6,7 @@ import take from 'lodash/array/take'
 import find from 'lodash/collection/find'
 
 import { isUserAdmin } from '../utils'
-import { deleteThread, toggleThreadLocked, deletePost } from '../updates'
+import { deleteThread, toggleThreadLocked, deletePost, toggleUpvote } from '../updates'
 
 import Thread from './Thread'
 
@@ -36,6 +36,7 @@ class Index extends Component {
     this.hideLockDialog = this.hideLockDialog.bind(this)
     this.showDeletePostDialog = this.showDeletePostDialog.bind(this)
     this.hideDeletePostDialog = this.hideDeletePostDialog.bind(this)
+    this.toggleUpvote = this.toggleUpvote.bind(this)
   }
 
   componentDidMount() {
@@ -114,6 +115,16 @@ class Index extends Component {
     this.hideLockDialog()
   }
 
+  toggleUpvote(postKey) {
+    const { submit } = this.props
+    const { value: posts = [] } = this.props.threadPosts || {}
+    const user = this.props.authenticatedUser
+    const post = find(posts, (threadPost) => {
+      return threadPost.key === postKey
+    })
+    submit(toggleUpvote({ postKey: postKey, post: post, user: user }))
+  }
+
   render() {
     const { key: threadKey, value: thread = {} } = this.props.thread || {}
     const { value: posts = [] } = this.props.threadPosts || {}
@@ -135,6 +146,7 @@ class Index extends Component {
       showLockDialog: this.showLockDialog,
       showDeletePostDialog: this.showDeletePostDialog,
       updateQuote: this.updateQuote,
+      toggleUpvote: this.toggleUpvote,
       selectLastPage: this.selectLastPage,
     }
 

--- a/src/Thread/Post.js
+++ b/src/Thread/Post.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link, styles } from 'refire-app'
 import { Row, Col, Card } from 'elemental'
 import ReactMarkdown from 'react-markdown'
+import includes from 'lodash/collection/includes'
 import { fromNow } from '../utils'
 import CodeBlock from '../App/CodeBlock'
 
@@ -48,7 +49,7 @@ const Post = ({
     )
   }
 
-let uid = user ? user.uid : undefined
+  const uid = user ? user.uid : undefined
 
   return (
     <Row>
@@ -120,7 +121,7 @@ let uid = user ? user.uid : undefined
               <UpvoteButton
                 user={user}
                 upvotes={Object.keys(post.likes || {}).length || 0}
-                liked = {Object.keys(post.likes || {}).includes(uid || {}) && post.likes[uid] === true}
+                liked = {includes(Object.keys(post.likes || {}),(uid) || {}) && post.likes[uid] === true}
                 onClick={() => toggleUpvote(postKey)}
                 styles={theme.UpvoteButton}
               />

--- a/src/Thread/Post.js
+++ b/src/Thread/Post.js
@@ -8,6 +8,7 @@ import CodeBlock from '../App/CodeBlock'
 import DeletePostButton from './DeletePostButton'
 import QuoteButton from './QuoteButton'
 import ReplyButton from './ReplyButton'
+import UpvoteButton from './UpvoteButton'
 
 const Post = ({
   postKey,
@@ -17,6 +18,7 @@ const Post = ({
   isAdmin,
   deletePost,
   updateQuote,
+  toggleUpvote,
   styles,
   theme,
 }) => {
@@ -45,6 +47,8 @@ const Post = ({
       </Row>
     )
   }
+
+let uid = user ? user.uid : undefined
 
   return (
     <Row>
@@ -112,6 +116,13 @@ const Post = ({
                 locked={locked}
                 onClick={() => updateQuote("", postKey)}
                 styles={theme.ReplyButton}
+              />
+              <UpvoteButton
+                user={user}
+                upvotes={Object.keys(post.likes || {}).length || 0}
+                liked = {Object.keys(post.likes || {}).includes(uid || {}) && post.likes[uid] === true}
+                onClick={() => toggleUpvote(postKey)}
+                styles={theme.UpvoteButton}
               />
             </div>
           </div>

--- a/src/Thread/Posts.js
+++ b/src/Thread/Posts.js
@@ -10,6 +10,7 @@ const Posts = ({
   isAdmin,
   deletePost,
   updateQuote,
+  toggleUpvote,
   styles,
   theme,
 }) => {
@@ -34,6 +35,7 @@ const Posts = ({
                 isAdmin={isAdmin}
                 deletePost={deletePost}
                 updateQuote={updateQuote}
+                toggleUpvote={toggleUpvote}
                 styles={theme.Post}
                 theme={theme}
               />

--- a/src/Thread/ReplyButton.js
+++ b/src/Thread/ReplyButton.js
@@ -22,6 +22,7 @@ const css = {
     color: "#555",
     display: "inline-block",
     verticalAlign: "top",
+    paddingRight: "20px",
   },
 }
 

--- a/src/Thread/Thread.js
+++ b/src/Thread/Thread.js
@@ -47,6 +47,7 @@ class Thread extends Component {
         showLockDialog,
         toggleLocked,
         updateQuote,
+        toggleUpvote,
       },
     } = this.props
     const { THREAD_PAGE_SIZE, THREAD_PAGE_LIMIT } = settings
@@ -115,6 +116,7 @@ class Thread extends Component {
             posts={pagedPosts}
             deletePost={showDeletePostDialog}
             updateQuote={updateQuote}
+            toggleUpvote={toggleUpvote}
             user={user}
             locked={thread.locked}
             isAdmin={isAdmin}

--- a/src/Thread/UpvoteButton.js
+++ b/src/Thread/UpvoteButton.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { styles } from 'refire-app'
+import FaThumbsOUp from 'react-icons/lib/fa/thumbs-o-up'
+import FaThumbsUp from 'react-icons/lib/fa/thumbs-up'
+
+const UpvoteButton = ({ user, upvotes, liked, onClick, styles }) => {
+  if (user) {
+    if (!liked) {
+      return (
+        <span onClick={onClick} title="Upvote">
+          <span className={styles.button}>
+            <FaThumbsOUp size="20px" /> {upvotes}
+          </span>
+        </span>
+      )
+    } else {
+      return (
+        <span onClick={onClick} title="Upvote">
+          <span className={styles.buttonActive}>
+            <FaThumbsUp size="20px" /> {upvotes}
+          </span>
+        </span>
+      )
+    }
+  } else {
+    return <span />
+  }
+}
+
+const css = {
+  button: {
+    cursor: "pointer",
+    color: "#555",
+    display: "inline-block",
+    verticalAlign: "top",
+    paddingRight: "20px",
+  },
+
+  buttonActive: {
+    cursor: "pointer",
+    color: "#55f",
+    display: "inline-block",
+    verticalAlign: "top",
+    paddingRight: "20px",
+  },
+}
+
+export default styles(css, UpvoteButton)

--- a/src/updates.js
+++ b/src/updates.js
@@ -94,3 +94,11 @@ export function saveSetting({ userId, setting, value }) {
     [`users/${userId}/settings/${setting}`]: value,
   }
 }
+
+export function toggleUpvote({ postKey, post, user }) {
+  const value = Object.keys(post.value.likes || {}).includes(user.uid) ? null : true
+  return {
+    [`posts/${postKey}/likes/${user.uid}`]: value,
+    [`users/${user.uid}/likes/${postKey}`]: value,
+  }
+}

--- a/src/updates.js
+++ b/src/updates.js
@@ -1,4 +1,5 @@
 import { firebase } from 'refire-app'
+import includes from 'lodash/collection/includes'
 
 export function newThread({ boardId, topic, text, user }) {
   const ref = firebase.database().ref()
@@ -96,7 +97,7 @@ export function saveSetting({ userId, setting, value }) {
 }
 
 export function toggleUpvote({ postKey, post, user }) {
-  const value = Object.keys(post.value.likes || {}).includes(user.uid) ? null : true
+  const value = includes(Object.keys(post.value.likes || {}),user.uid) ? null : true
   return {
     [`posts/${postKey}/likes/${user.uid}`]: value,
     [`users/${user.uid}/likes/${postKey}`]: value,


### PR DESCRIPTION
This adds a like button to posts with toggling behavior that keeps a two-way association between post and user.

I'm creating this PR because there may be an issue in refire or refire-app that it repros. You need to re-run the security-rules.json to try it. I'm new enough to redux that I may be doing something incorrectly.

Issue discussion:
The like button works as expected when clicking it on. When you click it off, however, the firebase paths are properly set to null and the keys dropped, but the redux store doesn't seem to get updated: the post object in the threadPosts binding still has the current user's key in it's likes subpath (even though it is gone from firebase). 