### PR TITLE
Update firebase-tools to allow deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "firebase-bolt": "^0.8.1",
-    "firebase-tools": "^3.1.0",
+    "firebase-tools": "^6.4.0",
     "json-loader": "^0.5.4",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",


### PR DESCRIPTION
Great project, kudos.

deploying with firebase-tools <4.1 no longer works, and generates this error:

> Error: HTTP Error: 410, This version of the Firebase CLI is no longer able to deploy to Firebase. Please upgrade to a newer version (>= 4.1.0). If you have further questions, please reach out to Firebase support.

Note: if firebase-tools is installed globally, users may need to run:

```
npm uninstall -g firebase-tools
where firebase-tools
rm -rf {firebase-tools directory}
npm install -g firebase-tools@6
```